### PR TITLE
now shows that +358 will be prefixed to registration phonenumber

### DIFF
--- a/src/main/js/cypress/integration/registration_form.spec.js
+++ b/src/main/js/cypress/integration/registration_form.spec.js
@@ -92,7 +92,7 @@ describe('Registration form', () => {
         error: { expired: true },
       },
     });
-    cy.get('[data-cy=input-phoneNumber]').type('+358401234567');
+    cy.get('[data-cy=input-phoneNumber]').type('401234567');
     cy.get('[data-cy=input-email]').type('test@test.com');
     cy.get('[data-cy=input-confirmEmail]').type('test@test.com');
     cy.get('[data-cy=form-submit-button]').click();
@@ -108,7 +108,7 @@ describe('Registration form', () => {
   it('suomi.fi authenticated user can fill and submit form', () => {
     cy.get('[data-cy=exam-details-card').should('exist');
 
-    cy.get('[data-cy=input-phoneNumber]').type('+358401234567');
+    cy.get('[data-cy=input-phoneNumber]').type('401234567');
     cy.get('[data-cy=input-email]').type('test@test.com');
     cy.get('[data-cy=input-confirmEmail]').type('test@test.com');
 
@@ -130,7 +130,7 @@ describe('Registration form', () => {
     cy.get('[data-cy=input-streetAddress]').type('Somestreet 11 A');
     cy.get('[data-cy=input-zip]').type('1234');
     cy.get('[data-cy=input-postOffice]').type('Somewhere');
-    cy.get('[data-cy=input-phoneNumber]').type('+358401234567');
+    cy.get('[data-cy=input-phoneNumber]').type('401234567');
 
     cy.get('[data-cy=select-nationality]').select('643');
     cy.get('[data-cy=input-birthdate]').type('10.10.1970');

--- a/src/main/js/src/components/Registration/RegistrationForm/RegistrationForm.js
+++ b/src/main/js/src/components/Registration/RegistrationForm/RegistrationForm.js
@@ -21,7 +21,8 @@ export const registrationForm = props => {
 
   function validatePhoneNumber(value) {
     if (value) {
-      const phoneNumber = parsePhoneNumberFromString(value);
+      // don't allow other than digits in input, since we inject the prefix ourselves
+      const phoneNumber = /^\d+$/.test(value) && parsePhoneNumberFromString("+358" + value);
       return phoneNumber && phoneNumber.isValid();
     } else {
       return true;
@@ -126,6 +127,28 @@ export const registrationForm = props => {
       </div>
     );
   };
+  const phoneNumberField = (name) => (
+    <React.Fragment>
+      <h3> {props.t(`registration.form.${name}`)}</h3>
+      <div className={classes.PhoneNumber}>
+        <div className={classes.PhoneNumberPrefix}>
+          +358
+        </div>
+        <Field
+          name={name}
+          data-cy={`input-${name}`}
+          type='tel'
+          aria-label={props.t(`registration.form.aria.${name}`)}
+        />
+      </div>
+      <ErrorMessage
+        name={name}
+        data-cy={`input-error-${name}`}
+        component="span"
+        className={classes.ErrorMessage}
+      />
+    </React.Fragment>
+  )
 
   const inputField = (name, placeholder = '', extra, type = 'text') => (
     <React.Fragment>
@@ -215,7 +238,7 @@ export const registrationForm = props => {
           post_office: values.postOffice,
           zip: values.zip,
           street_address: values.streetAddress,
-          phone_number: parsePhoneNumberFromString(values.phoneNumber).format(
+          phone_number: parsePhoneNumberFromString("+358" + values.phoneNumber).format(
             'E.164',
           ),
           email: values.email,
@@ -239,7 +262,7 @@ export const registrationForm = props => {
               <ZipAndPostOffice values={values} setFieldValue={setFieldValue} />
             </div>
             <div className={classes.FormElement}>
-              {inputField('phoneNumber', null, ' (+358)', 'tel')}
+              {phoneNumberField('phoneNumber')}
             </div>
             <div className={classes.FormElement}>
               {readonlyWhenExistsInput('email', initialValues, 'email')}

--- a/src/main/js/src/components/Registration/RegistrationForm/RegistrationForm.module.css
+++ b/src/main/js/src/components/Registration/RegistrationForm/RegistrationForm.module.css
@@ -72,6 +72,21 @@
   height: 28px;
 }
 
+.PhoneNumber {
+  width: 200px;
+}
+
+.PhoneNumberPrefix {
+  display: inline-block;
+  width: 20%;
+}
+
+.PhoneNumber input {
+  display: inline-block;
+  width: 75%;
+  height: 28px;
+}
+
 .NationalitySelect {
   height: 32px;
   width: 200px;

--- a/src/main/js/src/components/Registration/RegistrationForm/RegistrationForm.module.css
+++ b/src/main/js/src/components/Registration/RegistrationForm/RegistrationForm.module.css
@@ -73,7 +73,7 @@
 }
 
 .PhoneNumber {
-  width: 200px;
+  width: 210px;
 }
 
 .PhoneNumberPrefix {


### PR DESCRIPTION
Muutettu epäselvä teksti registrationFormin puhelinnumeron yhteydessä inputin eteen.

Tarkoitus on indikoida että +358 lisätään automaattisesti inputissa annettuun puhelinnumeroon. Onhan tämä oikein? Ymmärsin ettei sallita kuin +358 alkuisia.
Jos ei pidä paikkaansa niin voin tietysti lisätä oman inputin tolle suuntanumerolle.
Korjasin myös samalla validointia kentälle, ettei hyväksytä kirjaimia yms.