### PR TITLE
Add ISO-8859-1 charset to paytrail form

### DIFF
--- a/src/main/js/src/containers/PaymentRedirect/PaymentRedirect.js
+++ b/src/main/js/src/containers/PaymentRedirect/PaymentRedirect.js
@@ -41,6 +41,7 @@ export class PaymentRedirect extends Component {
         ref={this.paymentForm}
         action={this.state.formData.uri}
         method="POST"
+        acceptCharset="ISO-8859-1"
       >
         {this.state.formData.params.PARAMS_IN.split(',').map((p, i) => {
           return (


### PR DESCRIPTION
Add charset to paytrail form.

There was a bug where authcode was generated from backend using ISO-8859-1 charset, but paytrail calculated their authcode using field values sent as UTF-8 from yki-frontend.