### PR TITLE
Participant relocate fix

### DIFF
--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
@@ -196,9 +196,15 @@ const examSessionForm = props => {
     }
   };
 
+  const initialOfficeOid = props.examSessionContent
+    && props.examSessionContent.organizationChildren
+    && props.examSessionContent.organizationChildren.length > 0
+    ? props.examSessionContent.organizationChildren[0].oid
+    : '';
+
   // FIXME: no need for organizer param
-  const organizationSelection = (organizer, children, lang) => 
-    children.map(c => 
+  const organizationSelection = (organizer, children, lang) =>
+    children.map(c =>
       <option value={c.oid} key={c.oid}>
         {`${getLocalizedName(c.nimi, lang)} (${c.oid ? c.oid : ''})`}
       </option>
@@ -207,7 +213,7 @@ const examSessionForm = props => {
   return (
     <Formik
       initialValues={{
-        officeOid: '',
+        officeOid: initialOfficeOid,
         language: '',
         level: '',
         examDate: '',
@@ -224,8 +230,8 @@ const examSessionForm = props => {
       onSubmit={values => {
         const office = values.officeOid
           ? props.examSessionContent.organizationChildren.find(
-              o => o.oid === values.officeOid,
-            )
+            o => o.oid === values.officeOid,
+          )
           : null;
         const orgOrOfficeName = office
           ? office.nimi
@@ -459,9 +465,5 @@ const examSessionForm = props => {
   );
 };
 
-examSessionForm.propTypes = {
-  examSessionContent: PropTypes.object.isRequired,
-  onSubmit: PropTypes.func.isRequired,
-};
 
 export default withTranslation()(examSessionForm);

--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
@@ -465,5 +465,9 @@ const examSessionForm = props => {
   );
 };
 
+examSessionForm.propTypes = {
+  examSessionContent: PropTypes.object.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
 
 export default withTranslation()(examSessionForm);

--- a/src/main/js/src/components/UpcomingExamSessions/ParticipantList/ParticipantList.js
+++ b/src/main/js/src/components/UpcomingExamSessions/ParticipantList/ParticipantList.js
@@ -170,7 +170,7 @@ export const participantList = props => {
     } = props.examSession;
 
     const matchingOids = nextSession => {
-      if (nextExamSession.organizer_oid === organizer_oid) {
+      if (nextSession.organizer_oid === organizer_oid) {
         if (!nextSession.office_oid || !office_oid) return true;
         if (nextSession.office_oid === office_oid) return true;
       }

--- a/src/main/js/src/components/UpcomingExamSessions/ParticipantList/ParticipantList.js
+++ b/src/main/js/src/components/UpcomingExamSessions/ParticipantList/ParticipantList.js
@@ -13,14 +13,14 @@ import classes from './ParticipantList.module.css';
 import { ActionButton } from '../../UI/ActionButton/ActionButton';
 import ListExport from './ListExport/ListExport';
 
-const stateComparator = () => (a,b) => {
+const stateComparator = () => (a, b) => {
   if (a.state === 'COMPLETED')
     return -1;
   if (b.state === 'COMPLETED')
     return 1;
   if (a.state === "SUBMITTED")
     return -1;
-  if(b.state === "SUBMITTED")
+  if (b.state === "SUBMITTED")
     return 1;
 
   return 0;
@@ -166,16 +166,27 @@ export const participantList = props => {
       level_code,
       session_date,
       office_oid,
+      organizer_oid,
     } = props.examSession;
+
+    const matchingOids = nextSession => {
+      if (nextExamSession.organizer_oid === organizer_oid) {
+        if (!nextSession.office_oid || !office_oid) return true;
+        if (nextSession.office_oid === office_oid) return true;
+      }
+      return false;
+    }
+
     const canBeRelocatedTo = e => {
       return (
         moment(e.session_date).isAfter(moment(session_date)) &&
         e.level_code === level_code &&
         e.language_code === language_code &&
-        e.office_oid === office_oid &&
+        matchingOids(e) &&
         e.max_participants > e.participants
       );
     };
+
     const getNextSession = R.compose(
       R.head,
       R.sortBy(R.prop('session_date')),
@@ -211,7 +222,7 @@ export const participantList = props => {
 
   const handleFilterChange = event => {
     switch (event.target.value) {
-      case 'name': 
+      case 'name':
         setSortParticipantsFn(() => R.sortBy(R.path(['form', 'first_name'])));
         break;
       case 'state':
@@ -302,8 +313,8 @@ export const participantList = props => {
           {p.state === 'SUBMITTED'
             ? confirmPaymentButton(p)
             : p.state === 'COMPLETED'
-            ? relocateButton(p)
-            : null}
+              ? relocateButton(p)
+              : null}
         </div>
         <div className={classes.Item} />
         <div className={classes.Item}>{ssnOrBirthDate(p.form)}</div>
@@ -330,7 +341,7 @@ export const participantList = props => {
   };
 
   const participantsHeader = () => {
-    const post_admission_quota = 
+    const post_admission_quota =
       (props.examSession.post_admission_quota && props.examSession.post_admission_active) ? props.examSession.post_admission_quota : 0;
     return (
       <h2>


### PR DESCRIPTION
- Fixes an issue in exam session creation where when using the initial selected office the office_oid was left empty
- Because of this, when relocating participants, sessions with a null office oid are also accepted as a possible target session when other parameters match