### PR TITLE
OPHYKIKEH-7: improved end-user experience with radio buttons

### DIFF
--- a/src/main/js/src/components/UI/RadioButton/RadioButton.js
+++ b/src/main/js/src/components/UI/RadioButton/RadioButton.js
@@ -7,7 +7,7 @@ const radioButton = props => (
   <div
     className={[
       classes.RadioButton,
-      props.disabled ? classes.RadioButtonDisabled : '',
+      !props.disabled ? classes.RadioButtonEnabled : classes.RadioButtonDisabled,
     ].join(' ')}
   >
     <input

--- a/src/main/js/src/components/UI/RadioButton/RadioButton.js
+++ b/src/main/js/src/components/UI/RadioButton/RadioButton.js
@@ -7,7 +7,7 @@ const radioButton = props => (
   <div
     className={[
       classes.RadioButton,
-      !props.disabled ? classes.RadioButtonEnabled : classes.RadioButtonDisabled,
+      props.disabled ? classes.RadioButtonDisabled: classes.RadioButtonEnabled,
     ].join(' ')}
   >
     <input

--- a/src/main/js/src/components/UI/RadioButton/RadioButton.module.css
+++ b/src/main/js/src/components/UI/RadioButton/RadioButton.module.css
@@ -24,14 +24,8 @@
   color: hsla(0, 0%, 68%, 1);
 }
 
-.RadioButtonDisabled input {
-  cursor: not-allowed;
-}
-
-.RadioButtonDisabled .RadioButtonLabel {
-  cursor: not-allowed;
-}
-
+.RadioButtonDisabled input,
+.RadioButtonDisabled .RadioButtonLabel,
 .RadioButtonDisabled .RadioButtonExtraLabel {
   cursor: not-allowed;
 }

--- a/src/main/js/src/components/UI/RadioButton/RadioButton.module.css
+++ b/src/main/js/src/components/UI/RadioButton/RadioButton.module.css
@@ -5,19 +5,6 @@
   -webkit-appearance: radio;
 }
 
-.RadioButton:hover {
-  color: hsla(195, 100%, 47%, 1);
-}
-
-.RadioButtonDisabled {
-  color: hsla(0, 0%, 68%, 1);
-}
-
-.RadioButtonDisabled input {
-  margin-bottom: 0.5rem;
-  margin-right: 8px;
-}
-
 .RadioButtonLabel {
   display: inline-block;
   width: 17%;
@@ -27,6 +14,26 @@
 
 .RadioButtonExtraLabel {
   display: inline-block;
+}
+
+.RadioButtonEnabled:hover {
+  color: hsla(195, 100%, 47%, 1);
+}
+
+.RadioButtonDisabled {
+  color: hsla(0, 0%, 68%, 1);
+}
+
+.RadioButtonDisabled input {
+  cursor: not-allowed;
+}
+
+.RadioButtonDisabled .RadioButtonLabel {
+  cursor: not-allowed;
+}
+
+.RadioButtonDisabled .RadioButtonExtraLabel {
+  cursor: not-allowed;
 }
 
 @media screen and (min-width: 768px) and (max-width: 1020px) {

--- a/src/main/js/src/setupProxy.js
+++ b/src/main/js/src/setupProxy.js
@@ -337,13 +337,17 @@ module.exports = function (app) {
   });
 
   app.post('/yki/api/virkailija/organizer', (req, res) => {
-    try {
-      organizers.push(req.body);
-      res.send({ success: true });
-    } catch (err) {
-      printError(req, err);
-      res.status(404).send(err.message);
-    }
+    const mockCall = () => {
+      try {
+        organizers.push(req.body);
+        res.send({ success: true });
+      } catch (err) {
+        printError(req, err);
+        res.status(404).send(err.message);
+      }
+    };
+
+    useLocalProxy ? proxyPostCall(req, res) : mockCall();
   });
 
   app.get('/yki/api/virkailija/organizer/:oid/exam-session', (req, res) => {


### PR DESCRIPTION
Removed hover css from disabled radio button elements. Also changed cursor to `not-allowed` setting when inspecting a disabled radio button element. 

RadioButton elements are only used in `/yki/tutkintotilaisuudet` and `/ilmoittautuminen/tutkintotilaisuus/{id}` pages. Changes of this PR take place only in the former one given there can be no disabled elements in the latter.