### PR TITLE
OPHYKIKEH-2: learning institution must be manually selected for an exam session

### DIFF
--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
@@ -119,7 +119,7 @@ const examSessionForm = props => {
   const organizationSelection = (children, lang) => {
     let elements = [];
 
-    elements.push(<option value="" key="" disabled>Valitse toimipiste</option>)
+    elements.push(<option value="" key="">Valitse toimipiste</option>)
 
     if (children) {
       children.forEach(org => {
@@ -333,6 +333,11 @@ const examSessionForm = props => {
                   props.i18n.lang,
                 )}
               </Field>
+              <ErrorMessage
+                name="officeOid"
+                component="span"
+                className={classes.ErrorMessage}
+              />
             </div>
             <div className={classes.RadiobuttonGroup}>
               <RadioButtonGroup

--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
@@ -119,7 +119,7 @@ const examSessionForm = props => {
   const organizationSelection = (children, lang) => {
     let elements = [];
 
-    elements.push(<option value="" key="">Valitse toimipiste</option>)
+    elements.push(<option value="" key="">{props.t('examSession.selectInstitution')}</option>)
 
     if (children) {
       children.forEach(org => {

--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
@@ -41,6 +41,9 @@ const examSessionForm = props => {
   }
 
   const validationSchema = Yup.object().shape({
+    officeOid: Yup.string()
+      .required(props.t('error.mandatory'))
+      .oneOf(props.examSessionContent.organizationChildren.map(o => o.oid)),
     language: Yup.string().required(props.t('error.mandatory')),
     level: Yup.string().required(props.t('error.mandatory')),
     examDate: Yup.string()
@@ -112,6 +115,24 @@ const examSessionForm = props => {
       </div>
     );
   };
+
+  const organizationSelection = (children, lang) => {
+    let elements = [];
+
+    elements.push(<option value="" key="" disabled>Valitse toimipiste</option>)
+
+    if (children) {
+      children.forEach(org => {
+        elements.push(
+          <option value={org.oid} key={org.oid}>
+            {`${getLocalizedName(org.nimi, lang)} (${org.oid ? org.oid : ''})`}
+          </option>
+        )
+      })
+    }
+
+    return elements;
+  }
 
   const languageFields = languages => {
     const uniqueLanguageCodes = R.compose(R.uniq, R.pluck('language_code'));
@@ -208,25 +229,10 @@ const examSessionForm = props => {
     }
   };
 
-  const initialOfficeOid =
-    props.examSessionContent &&
-      props.examSessionContent.organizationChildren &&
-      props.examSessionContent.organizationChildren.length > 0
-      ? props.examSessionContent.organizationChildren[0].oid
-      : '';
-
-  const organizationSelection = (children, lang) =>
-    children &&
-    children.map(c => (
-      <option value={c.oid} key={c.oid}>
-        {`${getLocalizedName(c.nimi, lang)} (${c.oid ? c.oid : ''})`}
-      </option>
-    ));
-
   return (
     <Formik
       initialValues={{
-        officeOid: initialOfficeOid,
+        officeOid: '',
         language: '',
         level: '',
         examDate: '',

--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.module.css
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.module.css
@@ -32,6 +32,7 @@ textarea {
   border: 1px solid hsl(0, 0%, 68%);
   border-radius: 2px;
   background-color: hsl(0, 0%, 100%);
+  font-size: 0.875em;
 }
 
 .FormElement {

--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.test.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.test.js
@@ -119,6 +119,6 @@ describe('<ExamSessionForm />', () => {
         examSessionContent={examSessionContent}
       />,
     );
-    expect(form.find('select').children()).toHaveLength(2);
+    expect(form.find('select').children()).toHaveLength(3); // 2 organizations, 1 placeholder
   });
 });


### PR DESCRIPTION
UI improvement for exam session creation view which forces the end user to manually select the learning institution where the exam session is held. Error message "Pakollinen" is only shown if the end-user clicks the select element and leaves its value as the "placeholder" value. Decided to leave that placeholder element as non-disabled given that made more sense to me while testing it locally both ways (as enabled / disabled).

It would be better if the submit button was clickable even though the form wouldn't be valid. That way we could show the errors to the end-user then rather than having them "randomly" pop up if the user operates with certain elements leaving them with invalid values.