### PR TITLE
OPHYKIKEH-2: institution for a new exam session must be manually selected

### DIFF
--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.js
@@ -41,6 +41,9 @@ const examSessionForm = props => {
   }
 
   const validationSchema = Yup.object().shape({
+    officeOid: Yup.string()
+      .required(props.t('error.mandatory'))
+      .oneOf(props.examSessionContent.organizationChildren.map(o => o.oid)),
     language: Yup.string().required(props.t('error.mandatory')),
     level: Yup.string().required(props.t('error.mandatory')),
     examDate: Yup.string()
@@ -112,6 +115,24 @@ const examSessionForm = props => {
       </div>
     );
   };
+
+  const organizationSelection = (children, lang) => {
+    let elements = [];
+
+    elements.push(<option value="" key="">{props.t('examSession.selectInstitution')}</option>)
+
+    if (children) {
+      children.forEach(org => {
+        elements.push(
+          <option value={org.oid} key={org.oid}>
+            {`${getLocalizedName(org.nimi, lang)} (${org.oid ? org.oid : ''})`}
+          </option>
+        )
+      })
+    }
+
+    return elements;
+  }
 
   const languageFields = languages => {
     const uniqueLanguageCodes = R.compose(R.uniq, R.pluck('language_code'));
@@ -208,25 +229,10 @@ const examSessionForm = props => {
     }
   };
 
-  const initialOfficeOid =
-    props.examSessionContent &&
-      props.examSessionContent.organizationChildren &&
-      props.examSessionContent.organizationChildren.length > 0
-      ? props.examSessionContent.organizationChildren[0].oid
-      : '';
-
-  const organizationSelection = (children, lang) =>
-    children &&
-    children.map(c => (
-      <option value={c.oid} key={c.oid}>
-        {`${getLocalizedName(c.nimi, lang)} (${c.oid ? c.oid : ''})`}
-      </option>
-    ));
-
   return (
     <Formik
       initialValues={{
-        officeOid: initialOfficeOid,
+        officeOid: '',
         language: '',
         level: '',
         examDate: '',
@@ -327,6 +333,11 @@ const examSessionForm = props => {
                   props.i18n.lang,
                 )}
               </Field>
+              <ErrorMessage
+                name="officeOid"
+                component="span"
+                className={classes.ErrorMessage}
+              />
             </div>
             <div className={classes.RadiobuttonGroup}>
               <RadioButtonGroup

--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.module.css
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.module.css
@@ -32,6 +32,7 @@ textarea {
   border: 1px solid hsl(0, 0%, 68%);
   border-radius: 2px;
   background-color: hsl(0, 0%, 100%);
+  font-size: 0.875em;
 }
 
 .FormElement {

--- a/src/main/js/src/components/ExamSessionForm/ExamSessionForm.test.js
+++ b/src/main/js/src/components/ExamSessionForm/ExamSessionForm.test.js
@@ -119,6 +119,6 @@ describe('<ExamSessionForm />', () => {
         examSessionContent={examSessionContent}
       />,
     );
-    expect(form.find('select').children()).toHaveLength(2);
+    expect(form.find('select').children()).toHaveLength(3); // 2 organizations, 1 placeholder
   });
 });


### PR DESCRIPTION
Added "placeholder" element `Valitse oppilaitos` in organisation select element in new exam session creation page. Self-made translations for `examSession.selectInstitution` have been added in translations defined in untuvaopintopolku. Translations should be still checked with Tarja or Saara.

Error handling could be better here, for example by allowing the submit button to be clicked and at that point showing errors with each element having some. That way the user experience would be better and it would also be clearer, why the form cannot be submitted yet rather than now where the end-user may notice a disabled submit button at the bottom of the page while having missed the institution select element above. Then again I take it Pejam is also working on a info-button for the select element making it clearer one should select the institution manually first?