### PR TITLE
Show git commit id in page source

### DIFF
--- a/src/main/js/package.json
+++ b/src/main/js/package.json
@@ -43,9 +43,9 @@
     "start-server-and-test": "^1.7.13"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts start",
     "test": "react-scripts test",
-    "build": "react-scripts build",
+    "build": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts build",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "e2e-test": "BROWSER=none start-server-and-test start http://localhost:3000 cypress:run"

--- a/src/main/js/public/index.html
+++ b/src/main/js/public/index.html
@@ -11,6 +11,7 @@
       content="SPA for National Certificates of Language Proficiency (YKI)"
     />
     <meta name="theme-color" content="#000000" />
+    <meta name="ui-version" content="%REACT_APP_GIT_SHA%" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
Toimii lokaalisti, jää nähtäväksi toimiiko ci buildissa. Commit id:n voi laittaa index.html:ään minne vain, ehkä olisi fiksumpi laittaa se meta tagiin niin siihen pääsisi ohjelmallisesti käsiksi.