### PR TITLE
Feature/ophykiyp-19: latest axios and xlsx versions

### DIFF
--- a/src/main/js/package.json
+++ b/src/main/js/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/yki",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.21.4",
     "finnish-ssn": "^2.0.4",
     "flatpickr": "^4.5.7",
     "formik": "^1.5.2",
@@ -25,7 +25,7 @@
     "react-router-dom": "^5.1.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
-    "xlsx": "^0.14.2",
+    "xlsx": "^0.17.1",
     "yup": "^0.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated axios and xlsx to the latest available versions. Didn't notice any issues doing so although testing yet in untuva and QA environments would still be useful.

In order to update axios, I tried to look for potential issues that might emerge by going through its change log along with doing local testing, and searching for use cases of axios in the code. Code base for example uses Promise.all instead of axios.all that was most likely deprecated in 0.20.x. I don't think there are any other use cases of axios which would have required touching (based on the changes done since 0.18.0).

Axios change log since 0.18.0:
https://github.com/axios/axios/blob/master/CHANGELOG.md


Documentation and versions of xlsx found here:
https://www.npmjs.com/package/xlsx

Updating it to the most latest version didn't seem like a problematic thing to do. Tested yet Excel sheet exporting under http://localhost:3000/jarjestajarekisteri/:oid/tutkintotilaisuudet.
