### PR TITLE
OPHYKIKEH-48 Lock ua-parser-js version to surely uncompromised versio…

### DIFF
--- a/src/main/js/package-lock.json
+++ b/src/main/js/package-lock.json
@@ -7024,7 +7024,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "ua-parser-js": "0.7.18"
       }
     },
     "fd-slicer": {


### PR DESCRIPTION
…n, because version .19 is compromised.