### PR TITLE
Fix: showing register button within post-admission period should not depend on queue status

### DIFF
--- a/src/main/js/dev/rest/examSessions/allExamSessions.json
+++ b/src/main/js/dev/rest/examSessions/allExamSessions.json
@@ -10,6 +10,61 @@
           "email": "contact.person@testi.invalid"
         }
       ],
+      "pa_participants": 7,
+      "post_admission_quota": 7,
+      "post_admission_start_date": "2023-03-03",
+      "post_admission_end_date": "2029-12-12",
+      "post_admission_active": true,
+      "office_oid": "1.2.246.562.5.22724043777",
+      "published_at": "2019-01-17T12:32:00.001Z",
+      "session_date": "2025-04-06",
+      "organizer_oid": "1.2.246.562.10.39706139523",
+      "id": 999,
+      "registration_start_date": "2019-02-01",
+      "location": [
+        {
+          "lang": "fi",
+          "extra_information": null,
+          "name": "FOOBARIA",
+          "other_location_info": "Sali Koivisto",
+          "street_address": "Töölöntullinkatu 8",
+          "post_office": "HELSINKI",
+          "zip": "00250"
+        },
+        {
+          "lang": "sv",
+          "extra_information": null,
+          "name": "FOOBARIA",
+          "other_location_info": "Hall Koivisto",
+          "street_address": "Töölöntullinkatu 8",
+          "post_office": "HELSINGFORSS",
+          "zip": "00250"
+        },
+        {
+          "lang": "en",
+          "extra_information": null,
+          "name": "FOOBARIA",
+          "other_location_info": "Hall Koivisto",
+          "street_address": "Töölöntullinkatu 8",
+          "post_office": "HELSINKI",
+          "zip": "00250"
+        }
+      ],
+      "exam_fee": "100.00",
+      "registration_end_date": "2020-01-01",
+      "queue_full": false,
+      "open": true
+    },
+    {
+      "level_code": "PERUS",
+      "max_participants": 20,
+      "language_code": "fin",
+      "participants": 20,
+      "contact": [
+        {
+          "email": "contact.person@testi.invalid"
+        }
+      ],
       "pa_participants": 0,
       "office_oid": "1.2.246.562.5.22724043777",
       "published_at": "2019-01-17T12:32:00.001Z",

--- a/src/main/js/dev/rest/examSessions/allExamSessions.json
+++ b/src/main/js/dev/rest/examSessions/allExamSessions.json
@@ -13,7 +13,7 @@
       "pa_participants": 7,
       "post_admission_quota": 7,
       "post_admission_start_date": "2023-03-03",
-      "post_admission_end_date": "2029-12-12",
+      "post_admission_end_date": "2024-12-12",
       "post_admission_active": true,
       "office_oid": "1.2.246.562.5.22724043777",
       "published_at": "2019-01-17T12:32:00.001Z",

--- a/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
+++ b/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
@@ -1,22 +1,21 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {useTranslation} from 'react-i18next';
-import {connect} from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
-import {DATE_FORMAT} from '../../../../common/Constants';
+import { DATE_FORMAT } from '../../../../common/Constants';
 import * as actions from '../../../../store/actions/index';
-import {useMobileView} from '../../../../util/customHooks';
+import { useMobileView } from '../../../../util/customHooks';
 import {
   getSpotsAvailableForSession,
   hasFullQueue,
   hasRoom,
-  isAdmissionEnded,
   isOpen,
   isPostAdmissionActive,
   isRegistrationPeriodEnded,
 } from '../../../../util/examSessionUtil';
-import {getDeviceOrientation, levelDescription} from '../../../../util/util';
+import { getDeviceOrientation, levelDescription } from '../../../../util/util';
 import classes from './ExamSessionListItem.module.css';
 
 const examSessionListItem = ({
@@ -55,52 +54,60 @@ const examSessionListItem = ({
 
   const location = (
     <div className={classes.Location}>
-      {name} <br/>
-      {address} <br/>
+      {name} <br />
+      {address} <br />
       <strong>{city}</strong>
     </div>
   );
 
-  const showAvailableSpots = hasRoom(session) && !isRegistrationPeriodEnded(session);
+  const showAvailableSpots =
+    hasRoom(session) && !isRegistrationPeriodEnded(session);
 
   const availableSpots = getSpotsAvailableForSession(session);
 
-  const availableSpotsText = availableSpots === 1
-    ? t('registration.examSpots.singleFree')
-    : t('registration.examSpots.free');
+  const availableSpotsText =
+    availableSpots === 1
+      ? t('registration.examSpots.singleFree')
+      : t('registration.examSpots.free');
 
-    const availability = (
-      <div>
-        <strong>
-          {showAvailableSpots ? (
-            <>
-              <span>{availableSpots}</span>
-              {' '}
-              <span>{availableSpotsText}</span>
-            </>
-          ) : (
-            <span>{t('registration.examSpots.full')}</span>
-          )}
-        </strong>
-      </div>
-    );
+  const availability = (
+    <div>
+      <strong>
+        {showAvailableSpots ? (
+          <>
+            <span>{availableSpots}</span> <span>{availableSpotsText}</span>
+          </>
+        ) : (
+          <span>{t('registration.examSpots.full')}</span>
+        )}
+      </strong>
+    </div>
+  );
 
-    const displayRegistrationPeriod = (startDate, endDate) => {
-      const start = moment(startDate).format(DATE_FORMAT);
-      const end = moment(endDate).format(DATE_FORMAT);
+  const displayRegistrationPeriod = (startDate, endDate) => {
+    const start = moment(startDate).format(DATE_FORMAT);
+    const end = moment(endDate).format(DATE_FORMAT);
 
-      if (start !== end) {
-        return `${start} ${t('registration.examDetails.card.time')} 10 - ${end} ${t('registration.examDetails.card.time')} 16`;
-      }
+    if (start !== end) {
+      return `${start} ${t(
+        'registration.examDetails.card.time',
+      )} 10 - ${end} ${t('registration.examDetails.card.time')} 16`;
+    }
 
-      return `${start} ${t('registration.examDetails.card.time')} 10 - 16`;
-    };
+    return `${start} ${t('registration.examDetails.card.time')} 10 - 16`;
+  };
 
   const displayPostAdmissionPeriod = isPostAdmissionActive(session);
 
   const registrationPeriodText = displayPostAdmissionPeriod
-    ? displayRegistrationPeriod(session.post_admission_start_date, session.post_admission_end_date)
-    : displayRegistrationPeriod(session.registration_start_date, session.registration_end_date);
+    ? displayRegistrationPeriod(
+        session.post_admission_start_date,
+        session.post_admission_end_date,
+      )
+    : displayRegistrationPeriod(
+        session.registration_start_date,
+        session.registration_end_date,
+      );
 
   const registrationPeriodAriaLabelText = displayPostAdmissionPeriod
     ? `${t('examSession.postAdmission')}: ${registrationPeriodText}`
@@ -108,93 +115,93 @@ const examSessionListItem = ({
 
   const registrationOpenDesktop = (
     <div>
-      {displayPostAdmissionPeriod && (
-        <p>{t('examSession.postAdmission')}:</p>
-      )}
+      {displayPostAdmissionPeriod && <p>{t('examSession.postAdmission')}:</p>}
       <p>{registrationPeriodText}</p>
     </div>
   );
 
-    const registrationOpenMobile = (
-      <div style={{display: 'block'}}>
-        <div className={classes.RegistrationOpen}>
-          {displayPostAdmissionPeriod ? (
-            t('examSession.postAdmission')
-          ) : (
-            t('common.registrationPeriod')
-          )}
-          {':'}
-          <span style={{marginLeft: 5}}>
-            {registrationPeriodText}
-          </span>
-        </div>
+  const registrationOpenMobile = (
+    <div style={{ display: 'block' }}>
+      <div className={classes.RegistrationOpen}>
+        {displayPostAdmissionPeriod
+          ? t('examSession.postAdmission')
+          : t('common.registrationPeriod')}
+        {':'}
+        <span style={{ marginLeft: 5 }}>{registrationPeriodText}</span>
       </div>
-    );
+    </div>
+  );
 
-    const getRegistrationButtonText = () => {
-      if (availableSpots) {
-        return t('registration.register');
-      }
+  const getRegistrationButtonText = () => {
+    if (availableSpots) {
+      return t('registration.register');
+    }
 
-      return t('registration.register.forQueue');
-    };
+    return t('registration.register.forQueue');
+  };
 
-    const srLabel = `${getRegistrationButtonText()} ${examLanguage} ${examLevel}. ${examDate}. ${name}, ${address}, ${city}. ${registrationPeriodAriaLabelText}, ${availableSpots} ${availableSpotsText}.`;
+  const srLabel = `${getRegistrationButtonText()} ${examLanguage} ${examLevel}. ${examDate}. ${name}, ${address}, ${city}. ${registrationPeriodAriaLabelText}, ${availableSpots} ${availableSpotsText}.`;
 
-    const registerButton = (
-      <div>
-        {!isRegistrationPeriodEnded(session) && !(isAdmissionEnded(session) && hasFullQueue(session)) && (
-          <button
-            className={`YkiButton ${classes.RegisterButton}`}
-            onClick={selectExamSession}
-            role="link"
-            aria-label={srLabel}
-            disabled={!isOpen(session)}
-          >
-            {getRegistrationButtonText()}
-          </button>
-        )}
-      </div>
-    );
+  // Don't show registration button if admission period (and possible post-admission period) has ended
+  // OR (if there are no places left (regular or post admission) AND queue is full)
+  const hideRegisterButton =
+    isRegistrationPeriodEnded(session) ||
+    (!hasRoom(session) && hasFullQueue(session));
 
-    return (
-      <>
-        {mobile ||
-        tablet ||
-        (tablet && getDeviceOrientation() === 'landscape') ? (
-          <tr
-            className={classes.ExamSessionListItem}
-            data-cy="exam-session-list-item"
-          >
-            <td>
-              <div>{exam}</div>
-              <div>{date}</div>
-            </td>
-            <td>{registrationOpenMobile}</td>
-            <td>
-              <div>{availability}</div>
-              <div>{examFee}</div>
-            </td>
-            <td>
-              {location}
-              {registerButton}
-            </td>
-          </tr>
-        ) : (
-          <tr
-            className={classes.ExamSessionListItem}
-            data-cy="exam-session-list-item"
-          >
-            <td>{exam}</td>
-            <td>{date}</td>
-            <td>{location}</td>
-            <td>{registrationOpenDesktop}</td>
-            <td>{availability}</td>
-            <td>{registerButton}</td>
-          </tr>
-        )}
-      </>
-    );
+  const registerButton = (
+    <div>
+      {!hideRegisterButton && (
+        <button
+          className={`YkiButton ${classes.RegisterButton}`}
+          onClick={selectExamSession}
+          role="link"
+          aria-label={srLabel}
+          disabled={!isOpen(session)}
+        >
+          {getRegistrationButtonText()}
+        </button>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      {mobile ||
+      tablet ||
+      (tablet && getDeviceOrientation() === 'landscape') ? (
+        <tr
+          className={classes.ExamSessionListItem}
+          data-cy="exam-session-list-item"
+        >
+          <td>
+            <div>{exam}</div>
+            <div>{date}</div>
+          </td>
+          <td>{registrationOpenMobile}</td>
+          <td>
+            <div>{availability}</div>
+            <div>{examFee}</div>
+          </td>
+          <td>
+            {location}
+            {registerButton}
+          </td>
+        </tr>
+      ) : (
+        <tr
+          className={classes.ExamSessionListItem}
+          data-cy="exam-session-list-item"
+        >
+          <td>{exam}</td>
+          <td>{date}</td>
+          <td>{location}</td>
+          <td>{registrationOpenDesktop}</td>
+          <td>{availability}</td>
+          <td>{registerButton}</td>
+        </tr>
+      )}
+    </>
+  );
 };
 
 examSessionListItem.propTypes = {

--- a/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
+++ b/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
@@ -144,7 +144,7 @@ const examSessionListItem = ({
 
   // Don't show registration button if admission period (and possible post-admission period) has ended
   // OR we're within regular admission period and both ordinary quota and queue are full
-  // OR we're within post admission period and ordinary quota is full (as notifications are not sent to queue outside of the regular admission period.).
+  // OR we're within post admission period and ordinary quota is full (as notifications are not sent to queue outside the regular admission period.).
   const hideRegisterButton =
     isRegistrationPeriodEnded(session) ||
     (!hasRoom(session) &&

--- a/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
+++ b/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
@@ -11,6 +11,7 @@ import {
   getSpotsAvailableForSession,
   hasFullQueue,
   hasRoom,
+  isAdmissionEnded,
   isOpen,
   isPostAdmissionActive,
   isRegistrationPeriodEnded,

--- a/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
+++ b/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
@@ -143,10 +143,12 @@ const examSessionListItem = ({
   const srLabel = `${getRegistrationButtonText()} ${examLanguage} ${examLevel}. ${examDate}. ${name}, ${address}, ${city}. ${registrationPeriodAriaLabelText}, ${availableSpots} ${availableSpotsText}.`;
 
   // Don't show registration button if admission period (and possible post-admission period) has ended
-  // OR (if there are no places left (regular or post admission) AND queue is full)
+  // OR we're within regular admission period and both ordinary quota and queue are full
+  // OR we're within post admission period and ordinary quota is full (as notifications are not sent to queue outside of the regular admission period.).
   const hideRegisterButton =
     isRegistrationPeriodEnded(session) ||
-    (!hasRoom(session) && hasFullQueue(session));
+    (!hasRoom(session) &&
+      (hasFullQueue(session) || isPostAdmissionActive(session)));
 
   const registerButton = (
     <div>

--- a/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
+++ b/src/main/js/src/components/Registration/ExamSessionList/ExamSessionListItem/ExamSessionListItem.js
@@ -142,7 +142,7 @@ const examSessionListItem = ({
 
     const registerButton = (
       <div>
-        {!isRegistrationPeriodEnded(session) && !hasFullQueue(session) && (
+        {!isRegistrationPeriodEnded(session) && !(isAdmissionEnded(session) && hasFullQueue(session)) && (
           <button
             className={`YkiButton ${classes.RegisterButton}`}
             onClick={selectExamSession}


### PR DESCRIPTION
Nykytila:
- ilmoittautumispainike piilotetaan jos ilmoittautumisaika (ml. mahdollinen jälki-ilmoittautuminen) on mennyt TAI jos jono täynnä (riippumatta siitä onko varsinaisia paikkoja vapaana esim. peruutusten myötä)
- jos varsinaiset paikat ovat täynnä mutta jono ei, painike kehottaa ilmoittautumaan varasijalle

Tavoitetila:
- piilotetaan jos ilmoittautumisaika on mennyt (ml. mahd. jälki-ilmoittautuminen) TAI jos sekä varsinaiset paikat että jono on täynnä
- peruutuspaikoista ei lähetetä viestiä varsinaisen ilmoittautumisajan sulkeuduttua, joten jonoon ei myöskään pitäisi päästä ilmoittautumaan varsinaisen ilmoittautumisajan jälkeen