### PR TITLE
Remove browser update prompt

### DIFF
--- a/src/main/js/public/index.html
+++ b/src/main/js/public/index.html
@@ -34,35 +34,6 @@
     -->
     <title>YKI</title>
     <script>
-      var $buoop = {
-        required: {
-          e: 1,
-          i: 12,
-          f: 1,
-          o: 1,
-          s: 1,
-          c: 1,
-        },
-        reminder: 0,
-        reminderClosed: 0,
-        newwindow: true,
-        insecure: false,
-        unsupported: false,
-        no_permanent_hide: true,
-        api: 2019.04,
-      };
-      function $buo_f() {
-        var e = document.createElement('script');
-        e.src = '//browser-update.org/update.min.js';
-        document.body.appendChild(e);
-      }
-      try {
-        document.addEventListener('DOMContentLoaded', $buo_f, false);
-      } catch (e) {
-        window.attachEvent('onload', $buo_f);
-      }
-    </script>
-    <script>
       (function() {
         if (window.location.href.includes('virkailija')) {
           document.write(


### PR DESCRIPTION
The call to browser-update.org isn't something we've really known about. It was detected due to some changes to OPH-wide CSP rules being tested. Seems easier to remove the call than to try to support it.