### PR TITLE
update maven-wrapper to 3.6.3

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip


### PR DESCRIPTION
Tässä repossa käytetään spring-boot-starter-parent 3.4.4:ia, josta valuu maven - riippuvuus 3.6.3
